### PR TITLE
[MM] Implement arena allocator

### DIFF
--- a/allocator/allocator.h
+++ b/allocator/allocator.h
@@ -3,40 +3,117 @@
 
 #include "interpreter/register.h"
 #include "interpreter/types/coretypes.h"
+#include <sys/mman.h>
 #include <vector>
 #include <cstdint>
 #include <new>
 
 namespace k3s {
 
-using Payload = Register;
 
-class Allocator {
+class Allocator
+{
+    static constexpr uintptr_t ALLOC_START_ADDR = 0xE000000;
+    static constexpr uintptr_t ALLOC_SIZE = 1024 * 1024 * 32;
+
+    template <uintptr_t START_PTR, size_t SIZE>
+    class Region
+    {
+        template <typename T>
+        class AllocatorRequirements
+        {
+        public:
+            using value_type = T;
+
+            [[nodiscard]] T* allocate(size_t n)
+            {
+                return Region::Alloc<T>(n);
+            }
+            void deallocate(T *ptr, size_t n)
+            {
+                return;
+            }
+        private:
+            Region *region_{};
+        };
+
+    public:
+        void Init()
+        {
+            *GetCursor() = sizeof(*GetCursor()); 
+        }
+
+        template <typename T>
+        auto Adapter()
+        {
+            return AllocatorRequirements<T>();
+        }
+        template <typename T>
+        static T *Alloc(size_t n_elems)
+        {
+            return reinterpret_cast<T *>(AllocBytes(n_elems * sizeof(T)));
+        }
+
+        static auto *GetCursor()
+        {
+            return reinterpret_cast<size_t *>(START_PTR);
+        }
+        
+        static void *GetStartPtr()
+        {
+            return reinterpret_cast<void *>(START_PTR);
+        }
+
+        coretypes::Function *NewFunction(size_t bc_offs)
+        {
+            void *ptr = AllocBytes(sizeof(coretypes::Function));
+            return new (ptr) coretypes::Function(bc_offs);
+        }
+
+        coretypes::Array *NewArray(size_t size)
+        {
+            void *ptr = AllocBytes(sizeof(coretypes::Array) + sizeof(coretypes::Array::elem_t) * size);
+            return new (ptr) coretypes::Array(size);
+        }
+
+        static void *AllocBytes(size_t n_bytes)
+        {
+            size_t new_cursor = *GetCursor() + n_bytes;
+            if (new_cursor > SIZE) {
+                LOG_FATAL(ALLOCATOR, "OOM");
+            }
+            auto allocated = GetStartPtr() + *GetCursor();
+            *GetCursor() = new_cursor;
+            return allocated;
+        }
+    };
+
 public:
-    void *Alloc(size_t n_elements)
+    Allocator()
     {
-        storage_.emplace_back(n_elements * sizeof(Payload));
-        return storage_.back().data();
+        void *buf = mmap(reinterpret_cast<void *>(ALLOC_START_ADDR), ALLOC_SIZE, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+        ASSERT(buf == reinterpret_cast<void *>(ALLOC_START_ADDR));
+        const_region_.Init();
+        runtime_region_.Init();
     }
-    
-    void *AllocBytes(size_t n_bytes)
+    ~Allocator()
     {
-        storage_.emplace_back(n_bytes);
-        return storage_.back().data();
+        munmap(reinterpret_cast<void *>(ALLOC_START_ADDR), ALLOC_SIZE);
     }
-    
-    coretypes::Function *AllocFunction(size_t bc_offs)
+
+    auto &ConstRegion()
     {
-        void *ptr = AllocBytes(sizeof(coretypes::Function));
-        return new (ptr) coretypes::Function(bc_offs);
+        return const_region_;
     }
-    coretypes::Array *AllocArray(size_t size)
+
+    auto &RuntimeRegion()
     {
-        void *ptr = AllocBytes(sizeof(coretypes::Array));
-        return new (ptr) coretypes::Array(size);
+        return runtime_region_;
     }
+
 private:
-    std::vector<std::vector<uint8_t>> storage_ {};
+    Region<ALLOC_START_ADDR, ALLOC_SIZE / 2> const_region_;
+    Region<ALLOC_START_ADDR + ALLOC_SIZE / 2, ALLOC_SIZE / 2> runtime_region_;
 };
 
 }  // namespace k3s

--- a/allocator/containers.h
+++ b/allocator/containers.h
@@ -1,0 +1,16 @@
+#ifndef ALLOCATOR_CONTAINERS_H
+#define ALLOCATOR_CONTAINERS_H
+
+#include "allocator.h"
+#include <vector>
+#include <array>
+namespace k3s {
+
+template <typename T>
+using ConstVector = std::vector<T, decltype(Allocator().ConstRegion().Adapter<T>())>;
+template <typename T>
+using ArenaVector = std::vector<T, decltype(Allocator().RuntimeRegion().Adapter<T>())>;
+
+}
+
+#endif  // ALLOCATOR_CONTAINERS_H

--- a/assembler/main.cpp
+++ b/assembler/main.cpp
@@ -8,7 +8,7 @@
 
 int main(int argc, char *argv[])
 {
-    if (argc < 2) {
+    if (argc <= 2) {
         LOG_FATAL(ASSEMBLER, "Please, provide file");
     }
     auto file = std::fopen(argv[1], "r");

--- a/benchmarks/fibbonaci.k3s
+++ b/benchmarks/fibbonaci.k3s
@@ -4,7 +4,7 @@
 .num ONE 1
 
 # idx of element from sequence 0, 1, 1, 2, 3, 5, 8, 13, ...
-.num N 9
+.num N 23
 
 .def Fib
 {

--- a/classfile/class_file.h
+++ b/classfile/class_file.h
@@ -3,6 +3,7 @@
 
 #include "common/macro.h"
 #include "interpreter/types/coretypes.h"
+#include "allocator/allocator.h"
 #include "interpreter/bytecode_instruction.h"
 #include <cstdint>
 #include <array>
@@ -101,18 +102,17 @@ public:
     /// Write classfile to \p fileptr
     void DumpClassFile(FILE *fileptr);
     /// Load classfile from \p fileptr
-    static int LoadClassFile(FILE *fileptr, ClassFileHeader *header,
-                            Vector<BytecodeInstruction> *instructions_buffer,
-                            ConstantPool *const_pool);
+    static int LoadClassFile(const char *fn, ClassFileHeader **header,
+                            BytecodeInstruction **instr_buffer,
+                            ConstantPool *const_pool, Allocator *allocator);
 
 private:
     /// Loads classfile to \p header header from \p fileptr
-    static int LoadHeader(FILE *fileptr, ClassFileHeader *header);
+    static ClassFileHeader *LoadHeader(void *fileptr);
     /// Loads code section to \p instructions_buffer_ from \p fileptr
-    static int LoadCodeSection(FILE *fileptr, const ClassFileHeader &header,
-                        Vector<BytecodeInstruction> *instructions_buffer);
+    static BytecodeInstruction *LoadCodeSection(void *fileptr);
     /// Loads constant pool to \p constant_pool from \p fileptr
-    static int LoadConstantPool(FILE *fileptr, ConstantPool *constant_pool);
+    static int LoadConstantPool(void *constpool_file, size_t bytes_count, ConstantPool *constant_pool);
     static size_t EstimateEncodingSize(const ConstantPool::Element &element);
     void AllocateBuffer();
     /// Interfaces foe writing classfile parts to file

--- a/interpreter/interpreter.h
+++ b/interpreter/interpreter.h
@@ -3,13 +3,8 @@
 
 #include "bytecode_instruction.h"
 #include "register.h"
-#include "allocator/allocator.h"
+#include "allocator/containers.h"
 #include "classfile/class_file.h"
-#include <vector>
-#include <array>
-
-template <typename T>
-using Vector = std::vector<T>;
 
 namespace k3s {
 
@@ -18,7 +13,7 @@ public:
     // Returns after execution of Opcode::RET with empty call stack
     int Invoke();
 
-    int LoadClassFile(FILE *fileptr);
+    int LoadClassFile(const char *fn);
 
     void SetProgram(BytecodeInstruction *program) {
         program_ = program;
@@ -102,20 +97,21 @@ private:
         {
             caller_pc_ = caller_pc;
             callee_ = callee_obj;
+            regs_.resize(16);
         }
     public:
         Register acc_ {};
-        Register regs_[256] {};
+        ArenaVector<Register> regs_;
         size_t caller_pc_ {};
         // This is used for implicit this inside functions:
         coretypes::Function *callee_ = nullptr;
     };
 
 private:
-    Allocator alloc_ {};
+    Allocator allocator_ {};
     size_t pc_ {};
-    Vector<InterpreterState> state_stack_ {};
-    Vector<BytecodeInstruction> instructions_buffer_{};
+    ArenaVector<InterpreterState> state_stack_;
+    BytecodeInstruction *instructions_buffer_{};
     BytecodeInstruction *program_ {};
     ConstantPool constant_pool_{};
 };

--- a/interpreter/types/array.h
+++ b/interpreter/types/array.h
@@ -10,13 +10,16 @@ namespace k3s::coretypes {
 
 class Array {
 public:
-    Array(size_t size) : data_(size) {}
+    using elem_t = Register;
+
+    Array(size_t size) : size_(size) {}
     Register &GetElem(size_t idx) { 
-        return data_.at(idx); 
+        return data_[idx]; 
     }
-    void SetElem(size_t idx, const Register &val) { data_.at(idx) = val; }
+    void SetElem(size_t idx, const Register &val) { data_[idx] = val; }
 private:
-    std::vector<Register> data_;
+    size_t size_;
+    elem_t data_[];
 };
 
 }


### PR DESCRIPTION
Arena is allocated at fixed address 0x0E000000 with size of 0x02000000 (32MB);
It is separated in two spaces - `ConstRegion` (0x0e000000-0x0f000000) and `RuntimeRegion` (0x0f000000-0x10000000) (each of 16 MB).
Classfile is mapped to `ConstRegion`, objects and stack is allocated in `RuntimeRegion`